### PR TITLE
Fixed RCE on gulp-styledocco

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var gutil       = require('gulp-util');
 var PluginError = gutil.PluginError;
 var through     = require('through2');
 var defaults    = require('lodash.defaults');
-var exec        = require('child_process').exec;
+var exec        = require('child_process').execFile;
 
 var PLUGIN_NAME = 'gulp-styledocco';
 
@@ -68,8 +68,9 @@ module.exports = function (options) {
     } else {
       args.push(firstFile.path);
     }
-
-    exec(bin + args.join(' '), function (error, stdout, stderr) {
+    var cmd = bin + args.join(' ');
+    cmd = cmd.split(' ');
+    exec(cmd[0], cmd.slice(1), function (error, stdout, stderr) {
       if (stderr) {
         gutil.log(stderr);
       }


### PR DESCRIPTION
### 📊 Metadata *

Command injection vulnerability 
#### Bounty URL:  https://www.huntr.dev/bounties/1-npm-gulp-styledocco

### ⚙️ Description *

gulp-styledocco is a StyleDocco plugin for gulp, this package are vulnerable to Command Injection. The argument options can be controlled by users without any sanitization. It was using `exec()` function which is vulnerable to **Command Injection** if it accepts user input and it goes through any sanitization or escaping.

### 💻 Technical Description *

The use of the `child_process` function `exec()` is highly discouraged if you accept user input and don't sanitize/escape them. I replaced it with `execFile()` which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

Install the package and run the below code, you'll need to have a PDF to test:
```javascript
var root = require("gulp-styledocco");
var gulp = require("gulp");
var options = {
  opt: 'docs',
  name: "123\"& touch Vulnerable& \""
}

gulp.src("./gulp-styledocco.js")
  .pipe(root(options));
```
A file named `Vulnerable` will be created in the current working directory.

![image](https://user-images.githubusercontent.com/16708391/92590524-0205e100-f2ba-11ea-976e-b0009d34ba86.png)


### 🔥 Proof of Fix (PoF) *

After applying the fix, run the PoC again and no files will be created. Hence command injection is mitigated.

![image](https://user-images.githubusercontent.com/16708391/92590623-282b8100-f2ba-11ea-815f-6615e007aaf7.png)


### 👍 User Acceptance Testing (UAT)

Only `execFile` is used, no breaking changes introduced.
